### PR TITLE
Support widget configurations on `@turnstile` blade directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ public function submit(Request $request)
 }
 ```
 
+### Customizing the widget
+
+Cloudflare Turnstile accepts a range of configurations values on the widget itself. You can customize that by passing an array of key-value pairs for the related parameters to `@turnstile()` directive. To learn more about these parameters, read [Cloudflare Docs on Turnstile Client-side Rendering](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations).
+
+```blade
+<form action="/" method="POST">
+    @turnstile([
+        'action' => 'login',
+        'cdata' => 'sessionid-123456789',
+        'callback' => 'callback',
+        'expired-callback' => 'expiredCallback',
+        'error-callback' => 'errorCallback',
+        'theme' => 'dark',
+        'tabindex' => 1,
+    ])
+
+    <button>
+        Submit
+    </button>
+</form>
+```
+
 ## Testing
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "spatie/laravel-ray": "^1.26"
+        "spatie/laravel-ray": "^1.26",
+        "spatie/pest-plugin-snapshots": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/resources/views/turnstileWidget.blade.php
+++ b/resources/views/turnstileWidget.blade.php
@@ -1,3 +1,10 @@
 <div class="cf-turnstile"
      data-sitekey="{{ config('services.turnstile.key') }}"
+     @if(isset($configurations['action'])) data-action="{{ $configurations['action'] }}" @endif
+     @if(isset($configurations['cdata'])) data-cdata="{{ $configurations['cdata'] }}" @endif
+     @if(isset($configurations['callback'])) data-callback="{{ $configurations['callback'] }}" @endif
+     @if(isset($configurations['expired-callback'])) data-expired-callback="{{ $configurations['expired-callback'] }}" @endif
+     @if(isset($configurations['error-callback'])) data-error-callback="{{ $configurations['error-callback'] }}" @endif
+     @if(isset($configurations['theme'])) data-theme="{{ $configurations['theme'] }}" @endif
+     @if(isset($configurations['tabindex'])) data-tabindex="{{ $configurations['tabindex'] }}" @endif
 ></div>

--- a/resources/views/turnstileWidget.blade.php
+++ b/resources/views/turnstileWidget.blade.php
@@ -1,0 +1,3 @@
+<div class="cf-turnstile"
+     data-sitekey="{{ config('services.turnstile.key') }}"
+></div>

--- a/resources/views/turnstileWidget.blade.php
+++ b/resources/views/turnstileWidget.blade.php
@@ -1,10 +1,4 @@
 <div class="cf-turnstile"
      data-sitekey="{{ config('services.turnstile.key') }}"
-     @if(isset($configurations['action'])) data-action="{{ $configurations['action'] }}" @endif
-     @if(isset($configurations['cdata'])) data-cdata="{{ $configurations['cdata'] }}" @endif
-     @if(isset($configurations['callback'])) data-callback="{{ $configurations['callback'] }}" @endif
-     @if(isset($configurations['expired-callback'])) data-expired-callback="{{ $configurations['expired-callback'] }}" @endif
-     @if(isset($configurations['error-callback'])) data-error-callback="{{ $configurations['error-callback'] }}" @endif
-     @if(isset($configurations['theme'])) data-theme="{{ $configurations['theme'] }}" @endif
-     @if(isset($configurations['tabindex'])) data-tabindex="{{ $configurations['tabindex'] }}" @endif
+     @foreach($configurations ?? [] as $key => $value) data-{{ $key }}="{{ $value }}" @endforeach
 ></div>

--- a/src/LaravelCloudflareTurnstileServiceProvider.php
+++ b/src/LaravelCloudflareTurnstileServiceProvider.php
@@ -30,7 +30,7 @@ class LaravelCloudflareTurnstileServiceProvider extends PackageServiceProvider
             return '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
         });
 
-        Blade::directive('turnstile', function (array|string $configurations = []) {
+        Blade::directive('turnstile', function (string $configurations) {
             return "<?php echo view('cloudflare-turnstile::turnstileWidget')->with('configurations', $configurations); ?>";
         });
 

--- a/src/LaravelCloudflareTurnstileServiceProvider.php
+++ b/src/LaravelCloudflareTurnstileServiceProvider.php
@@ -31,7 +31,7 @@ class LaravelCloudflareTurnstileServiceProvider extends PackageServiceProvider
         });
 
         Blade::directive('turnstile', function () {
-            return '<div class="cf-turnstile" data-sitekey="'.config('services.turnstile.key').'"></div>';
+            return "<?php echo view('cloudflare-turnstile::turnstileWidget'); ?>";
         });
 
         Rule::macro('turnstile', function () {

--- a/src/LaravelCloudflareTurnstileServiceProvider.php
+++ b/src/LaravelCloudflareTurnstileServiceProvider.php
@@ -30,8 +30,8 @@ class LaravelCloudflareTurnstileServiceProvider extends PackageServiceProvider
             return '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>';
         });
 
-        Blade::directive('turnstile', function () {
-            return "<?php echo view('cloudflare-turnstile::turnstileWidget'); ?>";
+        Blade::directive('turnstile', function (array|string $configurations = []) {
+            return "<?php echo view('cloudflare-turnstile::turnstileWidget')->with('configurations', $configurations); ?>";
         });
 
         Rule::macro('turnstile', function () {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can test', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/TurnstileBladeDirectiveTest.php
+++ b/tests/TurnstileBladeDirectiveTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use function Spatie\Snapshots\assertMatchesHtmlSnapshot;
+
+beforeEach(function () {
+    config()->set('services.turnstile.key', '1x00000000000000000000AA');
+    config()->set('services.turnstile.secret', '2x0000000000000000000000000000000AA');
+});
+
+it('can render a turnstile widget', function () {
+    $html = Blade::render('@turnstile');
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom action', function () {
+    $html = Blade::render("@turnstile(['action' => 'test-action'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom cdata', function () {
+    $html = Blade::render("@turnstile(['cdata' => 'test-cdata'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom callback', function () {
+    $html = Blade::render("@turnstile(['callback' => 'testCallback'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom expired callback', function () {
+    $html = Blade::render("@turnstile(['expired-callback' => 'testExpiredCallback'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom error callback', function () {
+    $html = Blade::render("@turnstile(['error-callback' => 'testErrorCallback'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a custom theme', function () {
+    $html = Blade::render("@turnstile(['theme' => 'dark'])");
+
+    assertMatchesHtmlSnapshot($html);
+});
+
+it('can render a turnstile widget with a tabindex', function () {
+    $html = Blade::render("@turnstile(['tabindex' => 1])");
+
+    assertMatchesHtmlSnapshot($html);
+});

--- a/tests/TurnstileScriptBladeDirectiveTest.php
+++ b/tests/TurnstileScriptBladeDirectiveTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use function Spatie\Snapshots\assertMatchesHtmlSnapshot;
+
+it('can render a turnstile script snippet', function () {
+    $html = Blade::render('@turnstileScripts');
+
+    assertMatchesHtmlSnapshot($html);
+});

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_action__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_action__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-action="test-action"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_callback__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_callback__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-callback="testCallback"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_cdata__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_cdata__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-cdata="test-cdata"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_error_callback__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_error_callback__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-error-callback="testErrorCallback"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_expired_callback__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_expired_callback__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-expired-callback="testExpiredCallback"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_theme__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_theme__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-theme="dark"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_tabindex__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_tabindex__1.html
@@ -1,0 +1,3 @@
+<html><body>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" data-tabindex="1"></div>
+</body></html>

--- a/tests/__snapshots__/TurnstileScriptBladeDirectiveTest__it_can_render_a_turnstile_script_snippet__1.html
+++ b/tests/__snapshots__/TurnstileScriptBladeDirectiveTest__it_can_render_a_turnstile_script_snippet__1.html
@@ -1,0 +1,1 @@
+<html><head><script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script></head></html>


### PR DESCRIPTION
Closes #1.

This PR allows the `@turnstile` blade directive to accept an array of key-value pairs [configuration values](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations) to customize the rendered Turnstile widget.

Besides, test cases and documentation for this feature are added.