### PR TITLE
prevent token from expiring when using Laravel Livewire

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^6.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0",
+        "orchestra/testbench": "^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",

--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -4,7 +4,9 @@
     @if ($attributes->has('wire:model'))
         wire:ignore
         data-callback="captchaCallback"
-        {{ $attributes->filter(fn($value, $key) => ! in_array($key, ['data-callback', 'wire:model'])) }}
+        data-expired-callback="captchaExpired"
+        data-timeout-callback="captchaExpired"
+        {{ $attributes->filter(fn($value, $key) => ! in_array($key, ['data-callback', 'data-expired-callback', 'data-timeout-callback', 'wire:model'])) }}
     @else
         {{ $attributes->whereStartsWith('data-') }}
     @endif
@@ -14,6 +16,10 @@
     <script>
         function captchaCallback(token) {
             @this.set("{{ $attributes->get('wire:model') }}", token);
+        }
+
+        function captchaExpired() {
+            window.turnstile.reset()
         }
     </script>
 @endif

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_wire_model__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_wire_model__1.html
@@ -1,9 +1,13 @@
 <html><body>
-<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" wire:ignore data-callback="captchaCallback"></div>
+<div class="cf-turnstile" data-sitekey="1x00000000000000000000AA" wire:ignore data-callback="captchaCallback" data-expired-callback="captchaExpired" data-timeout-callback="captchaExpired"></div>
 
     <script>
         function captchaCallback(token) {
             @this.set("captcha", token);
+        }
+
+        function captchaExpired() {
+            window.turnstile.reset()
         }
     </script>
 </body></html>


### PR DESCRIPTION
This is a developer experience improvement pull request. When using Laravel Livewire turnstile tokens would time out after a period of inactivity. The captcha widget would look like it was working but didn't store a valid token in the wire:model. The turnstile component would then fail to render leaving the end user no way to successfully complete the captcha. This code fixes that issue an lessens the boilerplate needed to implement turnstile with Livewire.