### PR TITLE
Turnstile validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ public function submit(Request $request)
 }
 ```
 
+Or simply use the `turnstile` rule directly.
+
+```php
+use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
+
+public function submit(Request $request)
+{
+    $request->validate([
+        'cf-turnstile-response' => ['required', 'turnstile'],
+    ]);
+}
+```
+
 ### Customizing the widget
 
 You can customize the widget by passing attributes to the `<x-turnstile />` component.

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ public function submit(Request $request)
 Or simply use the `turnstile` rule directly.
 
 ```php
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
-
 public function submit(Request $request)
 {
     $request->validate([

--- a/src/LaravelCloudflareTurnstileServiceProvider.php
+++ b/src/LaravelCloudflareTurnstileServiceProvider.php
@@ -3,6 +3,7 @@
 namespace RyanChandler\LaravelCloudflareTurnstile;
 
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 use RyanChandler\LaravelCloudflareTurnstile\View\Components\Turnstile as TurnstileComponent;
@@ -36,5 +37,20 @@ class LaravelCloudflareTurnstileServiceProvider extends PackageServiceProvider
         Rule::macro('turnstile', function () {
             return app(Turnstile::class);
         });
+
+        Validator::extend(
+            'turnstile',
+            function ($attribute, $value, $parameters, $validator) {
+                $rule = app(Turnstile::class);
+                $isPassed = $rule->passes($attribute, $value);
+                if ($isPassed) {
+                    return true;
+                }
+
+                $validator->setCustomMessages([
+                    $attribute => $rule->message()[0],
+                ]);
+            }
+        );
     }
 }


### PR DESCRIPTION
So that we can use the `Turnstile` validation rule without needing to import any dependencies.

Example:
```php
public function submit(Request $request)
{
    $request->validate([
        'cf-turnstile-response' => ['required', 'turnstile'],
    ]);
}
```