### PR TITLE
Fix: Wait for Livewire initialization

### DIFF
--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -26,19 +26,22 @@ $model = $attributes->has('wire:model') ? $attributes->get('wire:model') : null;
 
 @if ($model)
     <script>
-        function {{ $id }}Callback(token) {
-            @this.set("{{ $model }}", token);
-        }
+        document.addEventListener('livewire:initialized', () => {
+            function {{ $id }}Callback(token) {
+                @this.set("{{ $model }}", token);
+            }
 
-        function {{ $id }}ExpiredCallback() {
-            window.turnstile.reset();
-        }
-
-        @this.watch("{{ $model }}", (value, old) => {
-            // If there was a value, and now there isn't, reset the Turnstile.
-            if (!! old && ! value) {
+            function {{ $id }}ExpiredCallback() {
                 window.turnstile.reset();
             }
-        })
+
+
+            @this.watch("{{ $model }}", (value, old) => {
+                // If there was a value, and now there isn't, reset the Turnstile.
+                if (!!old && !value) {
+                    window.turnstile.reset();
+                }
+            })
+        });
     </script>
 @endif


### PR DESCRIPTION
When implementing it in a test project we see that sometimes we try to make use of Livewire functions before it is fully initialized.

Causing JS errors like the following:
`Uncaught TypeError: Cannot read properties of undefined (reading 'find')`

With this change we encapsulate functions inside a listener waiting for Livewire to be initialized.