### PR TITLE
Javascript callback function declarations changed

### DIFF
--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -27,11 +27,11 @@ $model = $attributes->has('wire:model') ? $attributes->get('wire:model') : null;
 @if ($model)
     <script>
         document.addEventListener('livewire:initialized', () => {
-            function {{ $id }}Callback(token) {
+            window.{{ $id }}Callback = function (token) {
                 @this.set("{{ $model }}", token);
             }
 
-            function {{ $id }}ExpiredCallback() {
+            window.{{ $id }}ExpiredCallback = function () {
                 window.turnstile.reset();
             }
 

--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -35,7 +35,6 @@ $model = $attributes->has('wire:model') ? $attributes->get('wire:model') : null;
                 window.turnstile.reset();
             }
 
-
             @this.watch("{{ $model }}", (value, old) => {
                 // If there was a value, and now there isn't, reset the Turnstile.
                 if (!!old && !value) {

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_ID_and_wire_model__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_custom_ID_and_wire_model__1.html
@@ -3,14 +3,13 @@
 
     <script>
         document.addEventListener('livewire:initialized', () => {
-            function custom_idCallback(token) {
+            window.custom_idCallback = function (token) {
                 @this.set("captcha", token);
             }
 
-            function custom_idExpiredCallback() {
+            window.custom_idExpiredCallback = function () {
                 window.turnstile.reset();
             }
-
 
             @this.watch("captcha", (value, old) => {
                 // If there was a value, and now there isn't, reset the Turnstile.

--- a/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_wire_model__1.html
+++ b/tests/__snapshots__/TurnstileBladeDirectiveTest__it_can_render_a_turnstile_widget_with_a_wire_model__1.html
@@ -3,14 +3,13 @@
 
     <script>
         document.addEventListener('livewire:initialized', () => {
-            function captchaCallback(token) {
+            window.captchaCallback = function (token) {
                 @this.set("captcha", token);
             }
 
-            function captchaExpiredCallback() {
+            window.captchaExpiredCallback = function () {
                 window.turnstile.reset();
             }
-
 
             @this.watch("captcha", (value, old) => {
                 // If there was a value, and now there isn't, reset the Turnstile.


### PR DESCRIPTION
Callback functions declared in blade template were not called when used with Livewire, without declaring them like following: 

`window.{{ $id }}Callback = function (token) {`
...

`window.{{ $id }}ExpiredCallback = function () {`

Laravel v12.14.1
Livewire v3.6.3



