### PR TITLE
Allow id's with dashes in em

### DIFF
--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -3,7 +3,7 @@
 ])
 
 @php
-if (! preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $id)) {
+if (! preg_match('/^[a-zA-Z_][a-zA-Z0-9_-]*$/', $id)) {
     throw new InvalidArgumentException("The Turnstile ID [{$id}] must start start with a letter or underscore, and can only contain alphanumeric or underscore characters.");
 }
 


### PR DESCRIPTION
Added `-` to the regex allowing for dashes in id's, e.g. `contact-form-turnstile`.