### PR TITLE
Fix | Conditional check for response status and issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/ryangjchandler/laravel-cloudflare-turnstile/security/policy
     about: Learn how to notify us for sensitive bugs
   - name: Report a bug
-    url: https://github.com/ryangjchandler/laravel-cloudflare-turnstile/issues/new
+    url: https://github.com/ryangjchandler/laravel-cloudflare-turnstile/issues/new?template=bug_report
     about: Report a reproducible bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-cloudflare-turnstile` will be documented in this file.
 
+## v3.0.4 - 2026-05-12
+
+### What's Changed
+
+* Fix conditional check for response status (Bug) by @matiasperrone in https://github.com/ryangjchandler/laravel-cloudflare-turnstile/pull/70
+
 ## v3.0.3 - 2026-03-19
 
 ### What's Changed

--- a/src/Client.php
+++ b/src/Client.php
@@ -14,7 +14,7 @@ class Client implements ClientInterface
 
     public function siteverify(string $response): SiteverifyResponse
     {
-        $response = Http::retry(3, 100)
+        $httpResponse = Http::retry(3, 100)
             ->asForm()
             ->acceptJson()
             ->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
@@ -22,11 +22,11 @@ class Client implements ClientInterface
                 'response' => $response,
             ]);
 
-        if ($response->ok()) {
+        if ($httpResponse->ok() && $httpResponse->json('success') === true)) {
             return SiteverifyResponse::success();
         }
 
-        return SiteverifyResponse::failure($response->json('error-codes'));
+        return SiteverifyResponse::failure($httpResponse->json('error-codes'));
     }
 
     public function dummy(): string

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ class Client implements ClientInterface
                 'response' => $response,
             ]);
 
-        if (! $response->ok()) {
+        if ($response->ok()) {
             return SiteverifyResponse::success();
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,7 @@ class Client implements ClientInterface
             ->asForm()
             ->acceptJson()
             ->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
-                'secret' => config('services.turnstile.secret'),
+                'secret' => $this->secret ?: config('services.turnstile.secret'),
                 'response' => $response,
             ]);
 


### PR DESCRIPTION
## Issues
- There is an error in: !ok => success
- There is no way to report a bug in this repository

## Changes

- Flips the if condition to return a success response when the HTTP call is “OK” and success is "true".
- Keeps returning a failure response with error-codes when the HTTP call is not “OK” or success is not "true".
- Uses constructor $secret if the variable is set and not empty, fallback to config if not