### PR TITLE
Fix: Client::siteverify() never checks success field (always fails on valid tokens)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -14,19 +14,38 @@ class Client implements ClientInterface
 
     public function siteverify(string $response): SiteverifyResponse
     {
-        $response = Http::retry(3, 100)
-            ->asForm()
-            ->acceptJson()
-            ->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
-                'secret' => config('services.turnstile.secret'),
-                'response' => $response,
-            ]);
+        try {
+            $response = Http::retry(3, 100)
+                ->asForm()
+                ->acceptJson()
+                ->post('https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+                    'secret' => config('services.turnstile.secret'),
+                    'response' => $response,
+                ]);
+        } catch (\Throwable) {
+            // Connection failure / non-2xx after exhausting retries
+            // (Http::retry() rethrows). Fail closed: a verification we
+            // could not complete must not be treated as solved.
+            // (Previously the unreachable path returned success(), which
+            // silently *bypassed* Turnstile whenever siteverify was down.
+            // If you require fail-open behaviour, override the
+            // ClientInterface binding in your application.)
+            return SiteverifyResponse::failure(['internal-error']);
+        }
 
         if (! $response->ok()) {
+            return SiteverifyResponse::failure(['internal-error']);
+        }
+
+        // The siteverify endpoint returns HTTP 200 for *every* token —
+        // valid or not — and reports the outcome in the JSON body's
+        // `success` field. Success must be derived from that field;
+        // otherwise a 200 response always falls through to failure().
+        if ($response->json('success') === true) {
             return SiteverifyResponse::success();
         }
 
-        return SiteverifyResponse::failure($response->json('error-codes'));
+        return SiteverifyResponse::failure((array) $response->json('error-codes'));
     }
 
     public function dummy(): string

--- a/tests/SiteverifyTest.php
+++ b/tests/SiteverifyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use RyanChandler\LaravelCloudflareTurnstile\Client;
+use RyanChandler\LaravelCloudflareTurnstile\Responses\SiteverifyResponse;
+
+it('returns success when siteverify responds 200 with success:true', function () {
+    Http::fake([
+        'challenges.cloudflare.com/turnstile/v0/siteverify' => Http::response([
+            'success' => true,
+            'error-codes' => [],
+        ], 200),
+    ]);
+
+    $result = (new Client('secret'))->siteverify('valid-token');
+
+    expect($result)->toBeInstanceOf(SiteverifyResponse::class)
+        ->and($result->success)->toBeTrue()
+        ->and($result->errorCodes)->toBe([]);
+});
+
+it('returns failure with error codes when siteverify responds 200 with success:false', function () {
+    Http::fake([
+        'challenges.cloudflare.com/turnstile/v0/siteverify' => Http::response([
+            'success' => false,
+            'error-codes' => ['invalid-input-response'],
+        ], 200),
+    ]);
+
+    $result = (new Client('secret'))->siteverify('bad-token');
+
+    expect($result->success)->toBeFalse()
+        ->and($result->errorCodes)->toContain('invalid-input-response');
+});
+
+it('fails closed when the siteverify endpoint is unreachable / non-2xx', function () {
+    Http::fake([
+        'challenges.cloudflare.com/turnstile/v0/siteverify' => Http::response('error', 500),
+    ]);
+
+    $result = (new Client('secret'))->siteverify('any-token');
+
+    expect($result->success)->toBeFalse();
+});


### PR DESCRIPTION
Fixes #72.

## Problem

`Client::siteverify()` never reads the siteverify response's `success` field. The Cloudflare siteverify endpoint returns **HTTP 200 for every request** (valid *or* invalid token) and reports the outcome in the JSON body. Because `$response->ok()` is `true`, control always falls through to `SiteverifyResponse::failure(...)` → **every valid token fails verification**, breaking every form using this package in production.

Additional defects on the same path:
- `! $response->ok()` returned `SiteverifyResponse::success()` → **fail-open**, Turnstile silently bypassed when siteverify is unreachable.
- `Http::retry(3, 100)` rethrows on connection failure / exhausted retries and there is no `try/catch` → uncaught exception (the `! ok()` branch is unreachable for a persistent 5xx).
- `error-codes` is `null` when absent but `SiteverifyResponse::failure(array)` requires an array → `TypeError`.

Affected v3.0.0–v3.0.3 and `main` (regressed in the v3.0.0 rewrite; the installed vendor file, the GitHub blob at the commit `composer.lock` pins for v3.0.3, and the `v3.0.3` tag share the identical SHA256 `3471e2d6…85c0a7`). There was no test covering `siteverify()`.

## Changes

- Derive success from `$response->json('success') === true`.
- Cast `error-codes` to `array`.
- `try/catch` around the request; **fail closed** on connection failure / non-2xx (documented in-code — apps wanting fail-open can override the `ClientInterface` binding).
- Add `tests/SiteverifyTest.php`: 200+`success:true` → success, 200+`success:false` → failure(+error-codes), unreachable/non-2xx → failure (fail-closed).

## Verification

`composer test` → **18 passed** (15 existing + 3 new), `composer format` (Pint) clean, `composer analyse` (PHPStan) no errors.

Fail-mode is intentionally fail-closed (a verification that could not be completed must not count as solved); happy to make it configurable instead if you prefer to preserve the previous fail-open default — let me know.